### PR TITLE
Embeds + Refresh Logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,9 +2541,9 @@
       "dev": true
     },
     "run-script-os": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.4.tgz",
-      "integrity": "sha512-7CyVTaS+B8h11w0CdyLHw+n01ZmUD01kbluxc8+qWAdJ6LvnThTWAbMFCndW9vPHBoMCaB2kXHv0SSTAUlHHhQ=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.5.tgz",
+      "integrity": "sha512-kLvUnf1SM1+gSH2bY1P41MNFaWdXaG2nkhoJS9WQNQxk6g9KNuncKderBLG7vOsp77GtQqNs0bEazxip/I6wfg=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fuse.js": "^6.4.6",
     "luxon": "^1.25.0",
     "node-ical": "^0.12.7",
-    "run-script-os": "^1.1.4"
+    "run-script-os": "^1.1.5"
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",

--- a/xiera/XieraMain.ts
+++ b/xiera/XieraMain.ts
@@ -165,7 +165,15 @@ client.on('message', async (message) => {
 async function switchboard(desiredAction: Array<string>): Promise<string|Discord.MessageEmbed>{
   if (desiredAction){
     console.log(`> Action: '${desiredAction[0]}' | '${desiredAction[1]}'`);
-    if (/^\s?uq/mi.test(desiredAction[0])){
+    if (/^s?uq2/mi.test(desiredAction[0])){
+      if (desiredAction[1]){
+        const results = await Event.searchEvents(desiredAction[1]);
+        return (results);
+      }
+      const results = await Event.searchUpcomingEventsEmbed();
+      return (results);
+    }
+    else if (/^\s?uq/mi.test(desiredAction[0])){
       if (desiredAction[1]){
         const results = await Event.searchEvents(desiredAction[1]);
         return(results);
@@ -174,6 +182,10 @@ async function switchboard(desiredAction: Array<string>): Promise<string|Discord
         const results = await Event.searchUpcomingEvents();
         return(results);
       }
+    }
+    else if (/^\s?casino2/mi.test(desiredAction[0])){
+      const results = await Event.searchUpcomingCasinoEventsEmbed();
+      return (results);
     }
     else if (/^\s?casino/mi.test(desiredAction[0])){
       const results = await Event.searchUpcomingCasinoEvents();

--- a/xiera/XieraMain.ts
+++ b/xiera/XieraMain.ts
@@ -167,7 +167,7 @@ async function switchboard(desiredAction: Array<string>): Promise<string|Discord
     console.log(`> Action: '${desiredAction[0]}' | '${desiredAction[1]}'`);
     if (/^s?uq2/mi.test(desiredAction[0])){
       if (desiredAction[1]){
-        const results = await Event.searchEvents(desiredAction[1]);
+        const results = await Event.searchEvents(desiredAction[1], true);
         return (results);
       }
       const results = await Event.searchUpcomingEventsEmbed();

--- a/xiera/components/DailyCrafting/DailyCrafting.ts
+++ b/xiera/components/DailyCrafting/DailyCrafting.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'fs';
 import { CraftingData, CraftingRewardsIndex, CraftingScheduleIndex } from './@types/DailyCrafting';
 const DateTime = require('luxon').DateTime;
 const TimeStrings = require('../Core/Date/TimeStrings').TimeStrings;
-const UTCStrings = require('../Core/Date/UTCStrings').UTCStrings;
 const Messages = require('../Core/Messages/Messages').Messages;
 const path = require('path');
 

--- a/xiera/components/Event/@types/Events.d.ts
+++ b/xiera/components/Event/@types/Events.d.ts
@@ -60,6 +60,7 @@ export interface SearchIndexEntity {
 export interface IndexedQueryEventObject{
   [index: number]: {
     title: string,
+    categoryId: number,
     startTime: string,
     endTime: string
   }

--- a/xiera/components/Event/Events.ts
+++ b/xiera/components/Event/Events.ts
@@ -350,7 +350,7 @@ export class Events{
         embed.setDescription(`Thanks for waiting! Here's what I could find for: \`${searchTerm}\``);
         if (omittedResults > 0){
           if (omittedResults == 1){
-            embed.setDescription(`Thanks for waiting! Here's what I could find for: \`${searchTerm}\`. There's also **${omittedResults}** more result for \`${searchTerm}\` that are scheduled to happen soon`);
+            embed.setDescription(`Thanks for waiting! Here's what I could find for: \`${searchTerm}\`. There's also **${omittedResults}** more result for \`${searchTerm}\` that is scheduled to happen soon`);
           }
           else{
             embed.setDescription(`Thanks for waiting! Here's what I could find for: \`${searchTerm}\`. There's also **${omittedResults}** more results for \`${searchTerm}\` that are scheduled to happen soon`);

--- a/xiera/components/Reset/Reset.ts
+++ b/xiera/components/Reset/Reset.ts
@@ -61,7 +61,7 @@ export class Reset {
     const weekday = LocalDate.getUTCDay();
     
     // Days until the desired weekday
-    let adjustedDate = date + 7 - (weekday + (7 - resetWeekday) %7) %7;
+    let adjustedDate = date + 7 - (weekday + (7 - resetWeekday)) %7;
 
     // Keep the current day if the current hour isn't past the reset hour
     if ((weekday == resetWeekday) && LocalDate.getUTCHours() < resetHour) adjustedDate -= 7;
@@ -138,8 +138,7 @@ export class Reset {
     embed.setDescription('There\'s a lot of different times when things reset around here. So here\'s a handy list of when things will reset.');
     embed.addFields(
       {name: '__Daily Crafting__', value: `Rewards Schedule: ${dcScheduleType}`},
-      {name: 'Resets', value: '`Daily at 04:00 UTC`', inline: true},
-      {name: `Next Reset`, value: `\`${TimeStrings.totalTimeString(DailyCrafting - now.getTime())}\``, inline: true},
+      {name: 'Daily at 04:00 UTC', value: `Resets: \`${TimeStrings.totalTimeString(DailyCrafting - now.getTime())}\`\n`},
 
       {name: '__Fresh Finds__', value: `Does not include featured items`},
       {name: 'Refreshes', value: '`Daily at 06:00 UTC`', inline: true},


### PR DESCRIPTION
Updated how the bot updates the data
* The bot will now skip events that have already passed the event's end time
* Overrides the configured refresh interval to update more frequently in the case there's fewer than 10 (currently hardcoded) events

Added testing embeds
* General Quest/Concert Events (both the next few and search results have embed modes)
* Casino Events